### PR TITLE
reader: graceful syscall.Read error handling

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -34,6 +34,11 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 	if r.closed {
 		return 0, io.EOF
 	}
+
+	if n == -1 {
+		n = 0
+	}
+
 	return
 }
 


### PR DESCRIPTION
Hi,

I'm using s-urbaniak/uevent and in some cases `syscall.Read` returns: (n:`-1`, err: `ENOBUFS "no buffer space available"`).
`bufio.(*Reader).ReadString` & subcalls don't like the -1 too much and panic: [source](https://github.com/golang/go/blob/1d47a1184a4718a34ab1df4d9bf05a284aba4c70/src/bufio/bufio.go#L106-L109)
It handles correctly the error if `n=0` and `err != nil` though.
This PR changes the -1 to 0 in case of error.

Best regards,
Pierre